### PR TITLE
in slides, rejig the layout of runnable code

### DIFF
--- a/chirun/themes/default/static/code.css
+++ b/chirun/themes/default/static/code.css
@@ -5,6 +5,13 @@
 	grid-gap: 0 var(--spacing);
 	margin: var(--spacing) 0;
 }
+.runnable-code-wrapper[data-format="slides"] {
+	grid-template:
+		"code output" 10rem "run ." / 3fr 2fr;
+	grid-gap: 0;
+	width: 90vw;
+	font-size: 0.7rem;
+}
 
 @media (max-width: 40rem) {
     .runnable-code-wrapper {
@@ -21,25 +28,34 @@
 	grid-area: run;
 	padding: calc(0.5 * var(--spacing));
 	font-size: inherit;
-	/*! border: none; */
+	justify-self: start;
 }
 
 .runnable-code-wrapper .code {
 	grid-area: code;
 	border: 1px solid var(--text-colour);
-	padding: var(--spacing);
+	padding: calc(0.5 * var(--spacing));
 	color: black;
 	background: white;
+	overflow: auto;
 }
 
 .runnable-code-wrapper .output {
 	grid-area: output;
-	padding: var(--spacing);
+	padding: calc(0.5 * var(--spacing));
 	border: 1px solid var(--text-colour);
 	border-top: none;
 	margin: 0;
 	max-height: 20em;
-	overflow-y: auto;
+	overflow: auto;
+}
+
+.runnable-code-wrapper[data-format="slides"] .output {
+    border-top: 1px solid var(--text-colour);
+}
+
+.runnable-code-wrapper .output pre {
+	margin-top: 0;
 }
 
 .runnable-code-wrapper .output .images :is(canvas,img) {

--- a/chirun/themes/default/static/code.js
+++ b/chirun/themes/default/static/code.js
@@ -372,6 +372,7 @@ class RunnableCodeElement extends HTMLElement {
         this.wrapper = shadowRoot.querySelector('.runnable-code-wrapper');
         this.output_display = shadowRoot.querySelector('.output');
         this.set_state('fresh');
+        this.wrapper.dataset.format = document.body.dataset.format;
 
         this.init_editor();
 

--- a/chirun/themes/default/templates/slides_reveal.html
+++ b/chirun/themes/default/templates/slides_reveal.html
@@ -7,6 +7,8 @@
 
 {% endblock stylesheets %}
 
+{% block body_attributes %}data-format="slides"{% endblock %}
+
 {% block body %}
     {% block customisation %}
         {% include "theme_customise.html" %}


### PR DESCRIPTION
The output is to the right of the code, and both have fixed width and height.

see #175