### PR TITLE
Include chapter numbers within headings

### DIFF
--- a/chirun/plasTeXRenderer/Renderers/ChirunRenderer/Sectioning.jinja2s
+++ b/chirun/plasTeXRenderer/Renderers/ChirunRenderer/Sectioning.jinja2s
@@ -29,7 +29,7 @@ name: document
 name: part chapter
 <!-- Latex Chapter/Part -->
 
-<h1 id="{{ obj.id }}">{{ obj.title }}</h1>
+<h1 id="{{ obj.id }}">{{ obj.fullTitle }}</h1>
 
 {{ obj }}
 


### PR DESCRIPTION
Using fullTitle rather than title causes the chapter heading to be rendered as "N Chaptername", slightly more consistent with compiled LaTeX documents.