### PR TITLE
Add alt text test for #5

### DIFF
--- a/unittests/images.py
+++ b/unittests/images.py
@@ -15,13 +15,19 @@ class ImageTest(ChirunCompilationTest):
         self.assertEqual(self.compilation.returncode, 0)
 
     def test_jpg_exists(self):
-        self.assertTrue(self.jpg_path.exists(), msg=f'The image is stored as an JPG at {self.jpg_path}')
+        self.assertTrue(self.jpg_path.exists(), msg=f'The image is stored as a JPG at {self.jpg_path}')
 
     def test_png_exists(self):
-        self.assertTrue(self.png_path.exists(), msg=f'The image is stored as an PNG at {self.png_path}')
+        self.assertTrue(self.png_path.exists(), msg=f'The image is stored as a PNG at {self.png_path}')
 
     def test_image_reference(self):
         soup = self.get_soup('index.html')
         img = soup.select('.item-content img')
         self.assertEqual(img[0]['src'], 'images/img-0001.jpg', msg='The jpg is embedded as an <img> tag.')
         self.assertEqual(img[1]['src'], 'images/img-0002.png', msg='The png is embedded as an <img> tag.')
+    
+    def test_alt_text(self):
+        soup = self.get_soup('index.html')
+        img = soup.select('.item-content img')
+        self.assertEqual(img[0]['alt'], 'Penrose tiling with curved metal accents', msg='The jpg has alt text as defined with alttext.')
+        

--- a/unittests/images/test.tex
+++ b/unittests/images/test.tex
@@ -1,10 +1,12 @@
 \documentclass{article}
 \usepackage{graphicx}
+\usepackage{chirun}
 
 \begin{document}
 \begin{figure}
 \includegraphics{Penrose_tiling_at_Oxford_Mathematical_Institute_small.jpg}
 \caption{JPG of the Penrose tiling at the entrance to the Andrew Wiles Building, found on wikimedia commons.}
+\alttext{Penrose tiling with curved metal accents}
 \end{figure}
 \begin{figure}
 \includegraphics{Uniform_tiling_circle_packings.png}


### PR DESCRIPTION
Simple \alttext test for a jpg image, verifying it produces the correct 'alt' tag in the output html.