### PR TITLE
remove fbox from ovalbox definition

### DIFF
--- a/chirun/plasTeXRenderer/Renderers/ChirunRenderer/fancybox.jinja2s
+++ b/chirun/plasTeXRenderer/Renderers/ChirunRenderer/fancybox.jinja2s
@@ -1,4 +1,4 @@
-name: fbox ovalbox Ovalbox
+name: ovalbox Ovalbox
 <span class="ovalbox">{{ obj }}</span>
 
 name: shadowbox


### PR DESCRIPTION
fixes #259, allowing fbox to be properly styled as a box as defined in the css