### PR TITLE
Prevent non-basic unicode characters breaking the logs

### DIFF
--- a/chirun/latex.py
+++ b/chirun/latex.py
@@ -252,7 +252,7 @@ class LatexRunner(object):
         stdout_tail = collections.deque(maxlen=8)
         cmd = [self.compiler] + self.args
         logger.info('Running {}: {}'.format(self.compiler, self.wd / self.args[-1]))
-        proc = Popen(cmd, stdout=PIPE, stderr=PIPE, cwd=str(self.wd), universal_newlines=True)
+        proc = Popen(cmd, stdout=PIPE, stderr=PIPE, cwd=str(self.wd), universal_newlines=True,errors="backslashreplace")
         for stdout_line in iter(proc.stdout.readline, ""):
             if not stdout_line.isspace():
                 stdout_tail.append(stdout_line)

--- a/chirun/markdownRenderer/__init__.py
+++ b/chirun/markdownRenderer/__init__.py
@@ -66,7 +66,7 @@ def rewrite_media_sources(soup, item):
                     out_file.parent.mkdir(exist_ok=True, parents=True)
 
                     if source_file.suffix == '.pdf':
-                        subprocess.run(['pdf2svg', source_file.name, str(out_file)])
+                        subprocess.run(['pdf2svg', source_file.name, str(out_file)],errors="backslashreplace")
                     else:
                         copyfile(source_file, out_file)
 

--- a/chirun/plasTeXRenderer/Imagers/pdf2svg.py
+++ b/chirun/plasTeXRenderer/Imagers/pdf2svg.py
@@ -27,7 +27,7 @@ class PDFSVG(pdf2svg.PDFSVG):
         with tempfile.TemporaryDirectory() as tmpdir:
             tmpdir = Path(tmpdir)
             pdf_path = tmpdir / 'image.pdf'
-            subprocess.run(['epstopdf', name, pdf_path])
+            subprocess.run(['epstopdf', name, pdf_path],errors="backslashreplace")
             return self.single_pdf_to_svg(pdf_path)
 
     def single_pdf_to_svg(self, name):

--- a/unittests/__init__.py
+++ b/unittests/__init__.py
@@ -129,6 +129,7 @@ from .structure import *
 from .theme_customisation import *
 from .tikz import *
 from .toc import *
+from .unicode import *
 from .verbatim import *
 from .xcolor import *
 

--- a/unittests/unicode.py
+++ b/unittests/unicode.py
@@ -1,0 +1,19 @@
+from . import ChirunCompilationTest
+
+
+class UnicodeTest(ChirunCompilationTest):
+    source_path = 'unicode'
+    compile_args = ['-f', 'test.tex']
+
+
+    def test_unicode(self):
+        """
+        Tests that raw unicode characters which are not formatted in UTF-8 do not cause crashes
+
+        Tests https://github.com/chirun-ncl/chirun/issues/271
+        """
+        soup = self.get_soup('index.html')
+        paras = soup.select('.item-content p')
+        #A break of issue #271 will result in pdfLaTeX failing to compile and the log output recording a subset of the bytes needed to represent the power 2.
+        
+        self.assertIn("This is a line containing ².",paras[0].text, msg = 'The document has compiled and the unicode character is in the webpage')

--- a/unittests/unicode/test.tex
+++ b/unittests/unicode/test.tex
@@ -1,0 +1,11 @@
+\documentclass{article}
+\usepackage{chirun}
+
+\title{Test of the power 2 unicode symbol}
+
+\begin{document}
+
+
+This is a line containing ².
+
+\end{document}


### PR DESCRIPTION
Fixes #271 

Adds errors=backslashreplace on uses of popen and subprocess.run

Adds a unit test to ensure that a document containing non-basic unicode characters compiles.