### PR TITLE
Enable tcolorbox to use named colors via xcolor definitions

### DIFF
--- a/chirun/plasTeXRenderer/Packages/tcolorbox/__init__.py
+++ b/chirun/plasTeXRenderer/Packages/tcolorbox/__init__.py
@@ -22,7 +22,7 @@ class tcolorbox(Environment):
         u = self.ownerDocument.userdata
         self.parser:plasTeX.Packages.xcolor.ColorParser = plasTeX.Packages.xcolor.ColorParser(
                 u.getPath('packages/xcolor/colors'),
-                u.getPath('packages/xcolor/target_model'))
+                u.getPath('packages/xcolor/target_model')) #copy of textcolor in xcolor.py to set up the parser correctly.
 
         res = Environment.invoke(self, tex)
         a = self.attributes

--- a/chirun/plasTeXRenderer/Packages/tcolorbox/__init__.py
+++ b/chirun/plasTeXRenderer/Packages/tcolorbox/__init__.py
@@ -1,6 +1,8 @@
 from chirun.plasTeXRenderer import add_package_templates
 import plasTeX.Packages.color
+import plasTeX.Packages.xcolor
 from plasTeX import Command, Environment, CSSStyles
+
 
 def latex2htmlcolor(*args, **kwargs):
     return plasTeX.Packages.color.latex2htmlcolor(*args, named=self.ownerDocument.userdata.getPath('packages/color/colors'), **kwargs)
@@ -17,6 +19,11 @@ class tcolorbox(Environment):
     def invoke(self, tex):
         self.title_style = CSSStyles()
 
+        u = self.ownerDocument.userdata
+        self.parser:plasTeX.Packages.xcolor.ColorParser = plasTeX.Packages.xcolor.ColorParser(
+                u.getPath('packages/xcolor/colors'),
+                u.getPath('packages/xcolor/target_model'))
+
         res = Environment.invoke(self, tex)
         a = self.attributes
         options = {}
@@ -27,11 +34,11 @@ class tcolorbox(Environment):
 
         colback = options.get('colback')
         if colback is not None:
-            self.style['background-color'] = colback
+            self.style['background-color'] = self.parser.parseColor(colback).html
 
         colframe = options.get('colframe')
         if colframe is not None:
-            self.style['border-color'] = colframe
+            self.style['border-color'] = self.parser.parseColor(colframe).html
 
         boxrule = options.get('boxrule')
         if boxrule is not None:

--- a/unittests/__init__.py
+++ b/unittests/__init__.py
@@ -126,6 +126,7 @@ from .slides import *
 from .splitlevel import *
 from .staticfile import *
 from .structure import *
+from .tcolorbox import *
 from .theme_customisation import *
 from .tikz import *
 from .toc import *

--- a/unittests/tcolorbox.py
+++ b/unittests/tcolorbox.py
@@ -1,0 +1,14 @@
+from . import ChirunCompilationTest
+
+class TColorBoxTest(ChirunCompilationTest):
+    source_path = 'tcolorbox'
+    compile_args = ['-f', 'test.tex']
+
+    def test_box_color(self):
+        r""" Test that custom colours are reflected in the background of the box.
+        """
+        soup = self.get_soup('index.html')
+
+        box = soup.find(name='div',style='background-color:#00FF00; border-color:#1E32B4')
+        self.assertIsNotNone(box)
+

--- a/unittests/tcolorbox/test.tex
+++ b/unittests/tcolorbox/test.tex
@@ -1,0 +1,14 @@
+\documentclass{article}
+\usepackage{chirun}
+\usepackage{xcolor}
+\usepackage{tcolorbox}
+
+\begin{document}
+\definecolor{myColour}{HTML}{00FF00}
+\definecolor{myColour2}{RGB}{30,50,180}
+
+\begin{tcolorbox}[colback=myColour,colframe=myColour2,title=Title of Box]    
+    This text is inside a box.
+\end{tcolorbox}
+
+\end{document}


### PR DESCRIPTION
Adapts the color interpretation in tcolorbox's invoke to use xcolor's ColorParser, allowing it to properly interpret a wider range of colors including named colors.

Also includes a unit test of this with colors defined in html and rgb space.